### PR TITLE
Fix: Improve error reporting for Drive file access issues

### DIFF
--- a/Client/Admin/Admin_JS.html
+++ b/Client/Admin/Admin_JS.html
@@ -660,12 +660,13 @@ function onYouTubeIframeAPIReady() {
     }
 
     function onProjectDataLoaded(jsonString) {
-      console.log("onProjectDataLoaded: Received data string length:", jsonString ? jsonString.length : 'null');
+      console.log("onProjectDataLoaded: Received data:", jsonString);
 
-      if (jsonString === null || jsonString === undefined) {
+      // Check for error object first
+      if (jsonString && typeof jsonString === 'object' && jsonString.error) {
           showLoading(false);
-          console.error("onProjectDataLoaded: Received null data string from server (Project or data file likely not found).");
-          displayMessage("Error: Could not load project data. Project or its data file may not exist.", false);
+          console.error(`onProjectDataLoaded: Received error object from server: ${jsonString.error}`);
+          displayMessage(`Error: Could not load project data. Server said: ${jsonString.error}`, false);
           adminApp.state.projectData = { projectId: adminApp.state.currentProjectId, title: "Error Loading", slides: [] };
           adminApp.state.currentSlideIndex = -1;
           if (editingProjectTitleEl) editingProjectTitleEl.textContent = `Error Loading Project (ID: ${adminApp.state.currentProjectId})`;
@@ -673,7 +674,26 @@ function onYouTubeIframeAPIReady() {
           return;
       }
 
+      // Existing check for null or undefined, though the object check above should catch most errors.
+      // This handles cases where the server might return `null` for reasons other than a structured error.
+      if (jsonString === null || jsonString === undefined) {
+          showLoading(false);
+          console.error("onProjectDataLoaded: Received null or undefined data from server (Project or data file likely not found).");
+          displayMessage("Error: Could not load project data. Project or its data file may not exist or the data is empty.", false);
+          adminApp.state.projectData = { projectId: adminApp.state.currentProjectId, title: "Error Loading", slides: [] };
+          adminApp.state.currentSlideIndex = -1;
+          if (editingProjectTitleEl) editingProjectTitleEl.textContent = `Error Loading Project (ID: ${adminApp.state.currentProjectId})`;
+          updateSlideThumbnailsUI();
+          return;
+      }
+      
+      // Proceed to parse if it's a string (expected good path)
       try {
+          if (typeof jsonString !== 'string') {
+            // This case should ideally be caught by the object check above if it's an error object.
+            // If it's some other non-string, non-error-object, it's unexpected.
+            throw new Error("Received data is not a JSON string or a recognized error object.");
+          }
           const loadedData = JSON.parse(jsonString);
           console.log("Parsed project data:", loadedData);
 

--- a/Server/AdminController.js
+++ b/Server/AdminController.js
@@ -512,28 +512,28 @@ function deleteProject(projectId) {
       Logger.log(`getProjectDataForEditing: Attempting to load data for projectId: ${projectId}`);
       if (!projectId) {
         Logger.log("getProjectDataForEditing: ProjectID is missing.");
-        return null;
+        return { error: "ProjectID is missing." };
       }
 
       // Find row index first
        const rowIndex = findRowIndexByValue(PROJECT_INDEX_SHEET_ID, PROJECT_INDEX_DATA_SHEET_NAME, COL_PROJECT_ID, projectId);
        if (!rowIndex) {
             Logger.log(`getProjectDataForEditing: Project with ID "${projectId}" not found in ProjectIndex.`);
-            return null;
+            return { error: `Project with ID "${projectId}" not found in ProjectIndex.` };
        }
 
        // Get row data to find the file ID
        const rowData = getSheetRowData(PROJECT_INDEX_SHEET_ID, PROJECT_INDEX_DATA_SHEET_NAME, rowIndex);
        if (!rowData) {
             Logger.log(`getProjectDataForEditing: Could not retrieve row data for project ${projectId} at row ${rowIndex}.`);
-            return null;
+            return { error: `Could not retrieve row data for project ${projectId} at row ${rowIndex}.` };
        }
 
       const projectDataFileId = rowData[COL_PROJECT_DATA_FILE_ID - 1];
 
       if (!projectDataFileId) {
         Logger.log(`getProjectDataForEditing: ProjectDataFileID is missing for project "${projectId}" in row ${rowIndex}.`);
-        return null;
+        return { error: `ProjectDataFileID is missing for project "${projectId}" in row ${rowIndex}.` };
       }
       Logger.log(`getProjectDataForEditing: Found ProjectDataFileID: ${projectDataFileId} for project ${projectId}.`);
 
@@ -545,8 +545,7 @@ function deleteProject(projectId) {
 
     } catch (e) {
       Logger.log(`Error in getProjectDataForEditing for projectId ${projectId}: ${e.toString()} \nStack: ${e.stack}`);
-      // Consider returning specific errors if needed, e.g., differentiate file read error from not found
-      return null;
+      return { error: `Failed to read project data from Google Drive: ${e.message}` };
     }
   }
 


### PR DESCRIPTION
I've modified the server-side and client-side admin code to provide you with more specific error messages when Google Drive encounters issues reading project data files.

- `Server/AdminController.js` (`getProjectDataForEditing`):
  - I changed this to return a structured error object `{ error: "message" }` instead of `null` when a Drive file read fails. This allows the client to distinguish Drive API errors from other issues like "file not found in sheet".
  - I also standardized other early exit conditions in the function to return a similar error object.

- `Client/Admin/Admin_JS.html` (`onProjectDataLoaded`):
  - I updated this to check for the new error object format from the server.
  - If an error object with a message is received, it now displays the specific error message to you, providing better context than the previous generic "file not found" message.

- `Server/ViewerController.js` and `Client/Viewer/Viewer_JS.html`:
  - I reviewed these files and confirmed that they already implement robust error handling that is compatible with the improved error structure, so no changes were needed.

This change will help you better understand the source of the problem if a project fails to load due to Google Drive API errors.