### PR TITLE
Fix: Address critical JavaScript errors in Viewer and Admin

### DIFF
--- a/Client/Admin/Admin_JS.html
+++ b/Client/Admin/Admin_JS.html
@@ -855,8 +855,8 @@ function safeDisposeCanvas() {
                   slide.slideMedia.videoOverlays = [];
               }
         // Ensure youtubeOptions exists for YouTube slides
-        if (slideData.slideMedia && slideData.slideMedia.type === 'youtube' && typeof slideData.slideMedia.youtubeOptions === 'undefined') {
-            slideData.slideMedia.youtubeOptions = { showClickToBeginButton: false }; // Default
+        if (slide.slideMedia && slide.slideMedia.type === 'youtube' && typeof slide.slideMedia.youtubeOptions === 'undefined') { // CORRECTED
+            slide.slideMedia.youtubeOptions = { showClickToBeginButton: false }; // CORRECTED
         }
               if (!slide.fabricCanvasJSON || !slide.fabricCanvasJSON.objects) {
               } else {

--- a/Client/Viewer/Viewer_JS.html
+++ b/Client/Viewer/Viewer_JS.html
@@ -2063,10 +2063,10 @@ function stopAndDestroyYouTubePlayer() {
         console.log("Stopping and destroying YouTube player...");
 
         // Clear intervals
-        if (playerQuestionCheckInterval) { // This is a global variable, ensure it's the one intended.
-            clearInterval(playerQuestionCheckInterval);
-            playerQuestionCheckInterval = null;
-            console.log("Cleared playerQuestionCheckInterval.");
+        if (viewerApp.state.playerQuestionCheckInterval) {
+            clearInterval(viewerApp.state.playerQuestionCheckInterval);
+            viewerApp.state.playerQuestionCheckInterval = null;
+            console.log("Cleared viewerApp.state.playerQuestionCheckInterval.");
         }
         // Assuming overlayPreviewInterval is also a global or appropriately scoped variable
         if (typeof overlayPreviewInterval !== 'undefined' && overlayPreviewInterval) {
@@ -2133,17 +2133,12 @@ function stopAndDestroyYouTubePlayer() {
         }
 
 
-        // Clean up overlays - Assuming cleanupAllVideoOverlays is a global function
-        if (typeof cleanupAllVideoOverlays === 'function') {
-            cleanupAllVideoOverlays();
-            console.log("Called cleanupAllVideoOverlays().");
-        } else {
-            // Fallback/manual cleanup if cleanupAllVideoOverlays is not defined or to be safe
-            // This combines logic from the original function's finally block
-            console.warn("cleanupAllVideoOverlays is not a function. Performing manual overlay cleanup.");
-            if (viewerApp && viewerApp.state) {
-                if (viewerApp.state.viewerFabricCanvas) {
-                    const canvas = viewerApp.state.viewerFabricCanvas;
+        // Clean up overlays
+        // Manual cleanup (previously in else, now primary as cleanupAllVideoOverlays was removed)
+        console.log("Performing manual overlay cleanup."); // Updated console message
+        if (viewerApp && viewerApp.state) {
+            if (viewerApp.state.viewerFabricCanvas) {
+                const canvas = viewerApp.state.viewerFabricCanvas;
                     const objectsToRemove = canvas.getObjects().filter(obj => 
                         obj.customType === 'videoTimestampOverlay' || 
                         obj.customType === 'clickToBeginButton' || 
@@ -2173,8 +2168,6 @@ function stopAndDestroyYouTubePlayer() {
                 overlayContainer.innerHTML = '';
                 console.log("Cleared videoOverlayContainer HTML.");
             }
-        }
-
         // Reset timeline - Assuming resetTimeline is a global function
         if (typeof resetTimeline === 'function') {
             resetTimeline();


### PR DESCRIPTION
This commit resolves several critical JavaScript bugs:

1.  **Viewer: Undefined `playerQuestionCheckInterval`**: I corrected `stopAndDestroyYouTubePlayer` in `Viewer_JS.html` to reference `viewerApp.state.playerQuestionCheckInterval` instead of a non-existent global variable.

2.  **Viewer: Missing `cleanupAllVideoOverlays` function**: I removed the call to the undefined `cleanupAllVideoOverlays()` function from `stopAndDestroyYouTubePlayer` in `Viewer_JS.html`. The existing manual cleanup logic within the function already covers the necessary tasks.

3.  **Admin: Undefined `slideData` variable**: In `onProjectDataLoaded` in `Admin_JS.html`, I corrected references from `slideData` to `slide` within the `forEach` loop that processes project slides, specifically when ensuring `youtubeOptions` exist.

4.  **Client-Side Utilities**: I reviewed the usage of the client-side `Utilities` object (for `getUuid`, `generateUuid`) in both Admin and Viewer. I confirmed that its usage in Admin for generating client-side IDs is correct. No problematic calls (e.g., mistaking it for a server-side utility) were identified in the codebase.