### PR TITLE
Fix: Handle null deferredYouTubeSetup in onYouTubeIframeAPIReady

### DIFF
--- a/Client/Admin/Admin_JS.html
+++ b/Client/Admin/Admin_JS.html
@@ -92,8 +92,8 @@ function onYouTubeIframeAPIReady() {
   adminApp.state.isYouTubeApiReady = true;
   console.log('Admin YouTube API Ready.');
   
-  // Process any deferred setup
-  if (adminApp.state.deferredYouTubeSetup) {
+  // Add null check
+  if (adminApp.state.deferredYouTubeSetup && adminApp.state.deferredYouTubeSetup.videoId) {
     const { videoId, retryCount = 0 } = adminApp.state.deferredYouTubeSetup;
     setTimeout(() => {
       if (isYouTubePlayerAvailable()) {


### PR DESCRIPTION
I added a null check for adminApp.state.deferredYouTubeSetup and adminApp.state.deferredYouTubeSetup.videoId in the onYouTubeIframeAPIReady function in Client/Admin/Admin_JS.html.

This prevents a potential race condition where the function might try to access properties of a null or undefined object, leading to an error. The check ensures that videoId is accessed only when deferredYouTubeSetup and its videoId property are valid.